### PR TITLE
Added support for python 3.12 and an ignore directive for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,5 @@ dmypy.json
 cython_debug/
 
 /.idea
+/.vscode
 *.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
             "pytest~=7.2",
             "pytest-cov~=4.0",
             "pytest-xdist~=3.2",
-            "pylint~=2.17",
+            "pylint~=3.0",
         ],
     },
     setup_requires=["setuptools-git-versioning"],


### PR DESCRIPTION
The version of pylint specified did not work with the latest python, so bumped it to the most recent version.

Also added .vscode to the .gitignore since I am now using this as a development option