### PR TITLE
Replace Dict with dict and List with list type hints

### DIFF
--- a/marshy/factory/dataclass_marshaller_factory.py
+++ b/marshy/factory/dataclass_marshaller_factory.py
@@ -1,6 +1,6 @@
 import dataclasses
 import inspect
-from typing import Type, Optional, List, get_type_hints, Tuple
+from typing import Type, Optional, get_type_hints, Tuple
 
 from marshy.errors import MarshallError
 from marshy.factory.marshaller_factory_abc import MarshallerFactoryABC
@@ -30,8 +30,8 @@ class DataclassMarshallerFactory(MarshallerFactoryABC):
 def get_property_configs_for_type(
     type_: Type,
     context: MarshyContext,
-    include: Optional[List[str]] = None,
-    exclude: Optional[List[str]] = None,
+    include: Optional[list[str]] = None,
+    exclude: Optional[list[str]] = None,
     exclude_dumped_values: Tuple = DataclassMarshallerFactory.exclude_dumped_values,
 ):
     property_configs = []
@@ -58,7 +58,7 @@ def get_property_configs_for_type(
     return property_configs
 
 
-def skip(name: str, include: Optional[List[str]], exclude: Optional[List[str]]) -> bool:
+def skip(name: str, include: Optional[list[str]], exclude: Optional[list[str]]) -> bool:
     if include is not None and name not in include:
         return True
     if exclude is not None and name in exclude:
@@ -70,8 +70,8 @@ def skip(name: str, include: Optional[List[str]], exclude: Optional[List[str]]) 
 def get_attr_configs_for_type(
     type_: Type,
     context: MarshyContext,
-    include: Optional[List[str]] = None,
-    exclude: Optional[List[str]] = None,
+    include: Optional[list[str]] = None,
+    exclude: Optional[list[str]] = None,
     exclude_dumped_values: Tuple = (None,),
 ):
     # noinspection PyDataclass
@@ -104,10 +104,10 @@ def get_attr_configs_for_type(
 def dataclass_marshaller(
     type_: Type,
     context: MarshyContext,
-    custom_attr_configs: Optional[List[AttrConfig]] = None,
-    custom_property_configs: Optional[List[PropertyConfig]] = None,
-    include: Optional[List[str]] = None,
-    exclude: Optional[List[str]] = None,
+    custom_attr_configs: Optional[list[AttrConfig]] = None,
+    custom_property_configs: Optional[list[PropertyConfig]] = None,
+    include: Optional[list[str]] = None,
+    exclude: Optional[list[str]] = None,
     exclude_dumped_values: Tuple = (None,),
 ):
     exclude_list = exclude or []

--- a/marshy/marshaller/iterable_marshaller.py
+++ b/marshy/marshaller/iterable_marshaller.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TypeVar, Iterable, List, Callable, Iterator
+from typing import TypeVar, Iterable, Callable, Iterator
 
 from marshy import ExternalType
 from marshy.marshaller.marshaller_abc import MarshallerABC
@@ -17,10 +17,10 @@ class IterableMarshaller(MarshallerABC[Iterable[T]]):
     item_marshaller: MarshallerABC[T]
     constructor: Callable[[Iterator[T]], Iterable[T]] = list
 
-    def load(self, item: List[ExternalType]) -> Iterable[T]:
+    def load(self, item: list[ExternalType]) -> Iterable[T]:
         loaded = self.constructor(self.item_marshaller.load(i) for i in item)
         return loaded
 
-    def dump(self, item: Iterable[T]) -> List[ExternalType]:
+    def dump(self, item: Iterable[T]) -> list[ExternalType]:
         dumped = [self.item_marshaller.dump(i) for i in item]
         return dumped

--- a/marshy/marshaller/tuple_marshaller.py
+++ b/marshy/marshaller/tuple_marshaller.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TypeVar, Iterable, List, Tuple, Union, Type
+from typing import TypeVar, Iterable, Tuple, Union, Type
 
 from marshy.types import ExternalItemType, ExternalType
 from marshy.marshaller.marshaller_abc import MarshallerABC
@@ -16,7 +16,7 @@ class TupleMarshaller(MarshallerABC[Iterable[T]]):
     marshalled_type: Type
     item_marshallers: Tuple[MarshallerABC[T], ...]
 
-    def load(self, item: Union[List[ExternalType], ExternalItemType]) -> Iterable[T]:
+    def load(self, item: Union[list[ExternalType], ExternalItemType]) -> Iterable[T]:
         if isinstance(item, dict):
             loaded = tuple(
                 m.load(item[f"t{i}"]) for i, m in enumerate(self.item_marshallers)
@@ -25,6 +25,6 @@ class TupleMarshaller(MarshallerABC[Iterable[T]]):
         loaded = tuple(m.load(i) for m, i in zip(self.item_marshallers, item))
         return loaded
 
-    def dump(self, item: Iterable[T]) -> List[ExternalType]:
+    def dump(self, item: Iterable[T]) -> list[ExternalType]:
         dumped = [m.dump(i) for m, i in zip(self.item_marshallers, item)]
         return dumped

--- a/marshy/marshaller/type_marshaller.py
+++ b/marshy/marshaller/type_marshaller.py
@@ -14,8 +14,8 @@ class TypeMarshaller(MarshallerABC[Type]):
 
     marshalled_type: Type = Type
     permitted_prefixes: Iterable[str] = field(default_factory=tuple)
-    _names_to_types: Dict[str, Type] = field(default_factory=dict)
-    _types_to_names: Dict[Type, str] = None
+    _names_to_types: dict[str, Type] = field(default_factory=dict)
+    _types_to_names: dict[Type, str] = None
 
     def __post_init__(self):
         types_to_names = {t: n for n, t in self._names_to_types.items()}

--- a/marshy/marshaller/union_marshaller.py
+++ b/marshy/marshaller/union_marshaller.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TypeVar, Optional, Dict, Type, List, Iterable
+from typing import TypeVar, Optional, Type, Iterable
 
 from marshy import ExternalType
 from marshy.marshaller.deferred_marshaller import DeferredMarshaller
@@ -16,8 +16,8 @@ class UnionMarshaller(MarshallerABC[T]):
     """
 
     marshalled_type: T
-    marshallers_by_name: Dict[str, MarshallerABC[T]]
-    names_by_type: Dict[Type, str] = field(default_factory=dict)
+    marshallers_by_name: dict[str, MarshallerABC[T]]
+    names_by_type: dict[Type, str] = field(default_factory=dict)
 
     def __post_init__(self):
         self.names_by_type.update(
@@ -27,13 +27,13 @@ class UnionMarshaller(MarshallerABC[T]):
             }
         )
 
-    def load(self, item: List[ExternalType]) -> T:
+    def load(self, item: list[ExternalType]) -> T:
         type_name = item[0]
         marshaller = self.marshallers_by_name[type_name]
         loaded = marshaller.load(item[1])
         return loaded
 
-    def dump(self, item: Optional[T]) -> List[ExternalType]:
+    def dump(self, item: Optional[T]) -> list[ExternalType]:
         type_name = self.names_by_type[item.__class__]
         marshaller = self.marshallers_by_name[type_name]
         dumped = marshaller.dump(item)

--- a/marshy/marshy_context.py
+++ b/marshy/marshy_context.py
@@ -14,8 +14,8 @@ T = TypeVar("T")
 
 @dataclass
 class MarshyContext:
-    marshallers_by_type: Dict[Type, MarshallerABC] = field(default_factory=dict)
-    factories: List[MarshallerFactoryABC] = field(default_factory=list)
+    marshallers_by_type: dict[Type, MarshallerABC] = field(default_factory=dict)
+    factories: list[MarshallerFactoryABC] = field(default_factory=list)
     injecty_context: Optional[InjectyContext] = field(
         default_factory=get_default_injecty_context
     )

--- a/marshy/types.py
+++ b/marshy/types.py
@@ -6,7 +6,7 @@ ExternalType = Union[
     bool,
     int,
     float,
-    List["marshy.types.ExternalType"],
+    list["marshy.types.ExternalType"],
     "marshy.types.ExternalItemType",
 ]
-ExternalItemType = Dict[str, ExternalType]
+ExternalItemType = dict[str, ExternalType]

--- a/tests/performance/fixtures.py
+++ b/tests/performance/fixtures.py
@@ -21,7 +21,7 @@ class Product:
     weight_in_kg: Optional[float] = None
     number_in_stock: Optional[int] = None
     active: bool = False
-    tags: List[Tag] = field(default_factory=list)
+    tags: list[Tag] = field(default_factory=list)
 
 
 product = Product(

--- a/tests/test_custom_marshalling.py
+++ b/tests/test_custom_marshalling.py
@@ -109,10 +109,10 @@ class DatasetMarshaller(MarshallerABC[Dataset]):
         else:
             # noinspection PyTypeChecker
             coordinates = item["coords"]
-        return Dataset(context.load(List[Coordinate], coordinates))
+        return Dataset(context.load(list[Coordinate], coordinates))
 
     def dump(self, item: Dataset) -> ExternalType:
-        dumped = dict(coords=context.dump(item.coordinates, List[Coordinate]))
+        dumped = dict(coords=context.dump(item.coordinates, list[Coordinate]))
         if item.coordinates:
             dumped["mean"] = context.dump(item.calculate_mean(), Coordinate)
             dumped["median"] = context.dump(item.calculate_median(), Coordinate)

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -10,7 +10,7 @@ from marshy import dump, load
 @dataclass
 class Nested:
     title: str
-    children: List[Nested] = field(default_factory=list)
+    children: list[Nested] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/test_impl_marshaller.py
+++ b/tests/test_impl_marshaller.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod, ABC
 from dataclasses import dataclass
-from typing import List
+from typing import List  # noqa
 from unittest import TestCase
 
 from injecty import create_injecty_context
@@ -45,9 +45,9 @@ class TestImplMarshaller(TestCase):
         injecty_context.register_impls(PetAbc, [Cat, Dog])
         context = create_marshy_context(injecty_context=injecty_context)
         pets = [Cat("Felix"), Dog("Rover")]
-        dumped = context.dump(pets, List[PetAbc])
+        dumped = context.dump(pets, list[PetAbc])
         assert dumped == [["Cat", dict(name="Felix")], ["Dog", dict(name="Rover")]]
-        loaded = context.load(List[PetAbc], dumped)
+        loaded = context.load(list[PetAbc], dumped)
         assert pets == loaded
         vocalizations = [p.vocalize() for p in loaded]
         assert ["Meow!", "Woof!"] == vocalizations

--- a/tests/test_marshall_deferred.py
+++ b/tests/test_marshall_deferred.py
@@ -14,7 +14,7 @@ class Node:
     id: str
     # The fact that Node references itself means we need deferred resolution of the marshaller
     # Since it will also reference itself
-    children: Optional[List[NodeTypeName]] = None
+    children: Optional[list[NodeTypeName]] = None
 
 
 class TestMarshallDeferred(TestCase):

--- a/tests/test_marshall_iterable.py
+++ b/tests/test_marshall_iterable.py
@@ -8,8 +8,8 @@ from marshy.errors import MarshallError
 class TestMarshallIterable(TestCase):
     def test_marshall(self):
         values = list(range(10))
-        dumped = dump(values, List[int])
-        loaded = load(List[int], dumped)
+        dumped = dump(values, list[int])
+        loaded = load(list[int], dumped)
         assert values == loaded
 
     def test_marshall_set(self):
@@ -20,7 +20,7 @@ class TestMarshallIterable(TestCase):
 
     def test_dump(self):
         values = [True, None, 1, "Mix"]
-        type_ = List[Union[bool, int, type(None), str]]
+        type_ = list[Union[bool, int, type(None), str]]
         dumped = dump(values, type_)
         loaded = load(type_, dumped)
         assert values == loaded

--- a/tests/test_marshall_obj.py
+++ b/tests/test_marshall_obj.py
@@ -24,7 +24,7 @@ class Customer:
     id: str
     full_name: str
     address: Optional[str] = None
-    purchases: Optional[List[PurchaseTypeName]] = None
+    purchases: Optional[list[PurchaseTypeName]] = None
 
 
 @dataclass
@@ -33,7 +33,7 @@ class Product:
     title: str
     description: Optional[str] = None
     weight_in_kg: Optional[float] = None
-    purchases: Optional[List[PurchaseTypeName]] = None
+    purchases: Optional[list[PurchaseTypeName]] = None
 
 
 @dataclass
@@ -60,7 +60,7 @@ class TestMarshallObj(TestCase):
                 ),
             ),
         )
-        value: Dict[str, Any] = dict(i=10, s="foo", f=12.2, b=True, n=None)
+        value: dict[str, Any] = dict(i=10, s="foo", f=12.2, b=True, n=None)
         dumped = marshaller.dump(value)
         assert "n" not in dumped
         loaded = marshaller.load(dumped)
@@ -78,7 +78,7 @@ class TestMarshallObj(TestCase):
                 attr_config(OptionalMarshaller(IntMarshaller()), "n"),
             ),
         )
-        value: Dict[str, Any] = dict(i=10, s="foo", f=12.2, b=True, n=None)
+        value: dict[str, Any] = dict(i=10, s="foo", f=12.2, b=True, n=None)
         dumped = marshaller.dump(value)
         assert "n" in dumped
         loaded = marshaller.load(dumped)

--- a/tests/test_marshall_optional.py
+++ b/tests/test_marshall_optional.py
@@ -7,7 +7,7 @@ from marshy import dump, load
 class TestMarshallIterable(TestCase):
     def test_marshall(self):
         values = [None, "b"]
-        type_ = List[Optional[str]]
+        type_ = list[Optional[str]]
         dumped = dump(values, type_)
         assert values == dumped
         loaded = load(type_, dumped)

--- a/tests/test_marshall_union.py
+++ b/tests/test_marshall_union.py
@@ -10,7 +10,7 @@ from marshy.marshaller.union_marshaller import implementation_marshaller
 class TestMarshallIterable(TestCase):
     def test_marshall(self):
         values = [True, None, 1, "Mix"]
-        type_ = List[Union[bool, int, type(None), str]]
+        type_ = list[Union[bool, int, type(None), str]]
         dumped = dump(values, type_)
         assert dumped == [
             ["bool", True],
@@ -22,7 +22,7 @@ class TestMarshallIterable(TestCase):
         assert values == loaded
 
     def test_marshall_nested(self):
-        type_ = Union[List[str], int]
+        type_ = Union[list[str], int]
         dumped = dump(["a", "b"], type_)
         assert dumped == ["list", ["a", "b"]]
         loaded = load(type_, dumped)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, Dict
+from typing import Union, Optional
 from unittest import TestCase
 
 from marshy.errors import MarshallError
@@ -23,6 +23,6 @@ class TestResolveForwardRefs(TestCase):
             resolve_forward_refs(Optional["NotARealClassName"])
 
     def test_dict(self):
-        type_ = Dict[str, "unittest.TestCase"]
+        type_ = dict[str, "unittest.TestCase"]
         type_ = resolve_forward_refs(type_)
-        assert type_ == Dict[str, TestCase]
+        assert type_ == dict[str, TestCase]


### PR DESCRIPTION
This PR replaces all Python Dict type hints with dict and List with list to follow modern Python type hinting conventions.